### PR TITLE
refactor: avoid destructuring for better IE11 support

### DIFF
--- a/src/a11y-dropdown-component.js
+++ b/src/a11y-dropdown-component.js
@@ -18,7 +18,7 @@ const Dropdowns = (() => {
       this.dropdown = document.getElementById(options.dropdown);
       this.items = this.dropdown.querySelectorAll('[data-item]');
       this.links = this.dropdown.querySelectorAll('[data-focus]');
-      [this.firstLink] = this.links;
+      this.firstLink = this.links[0];
       this.lastLink = this.links[this.links.length - 1];
 
       this.state = [];


### PR DESCRIPTION
Hi,

I used this library at work but I had to support IE11. We use Webpack Encore to build assets and use Babel, but apparently there is an issue with Babel which makes it use Symbol when polyfilling array destructuring (see https://github.com/babel/babel/issues/7597).

I had to make this change to make the lib work in IE11 even after it was processed by Babel.